### PR TITLE
fix: .progress-bar appearing as a square on Safari

### DIFF
--- a/Misc/07/style.css
+++ b/Misc/07/style.css
@@ -24,8 +24,7 @@ body {
 	height: 150px;
 	border-radius: 50%;
 	color: #fff;
-	outline: 2px solid #7effb2;
-	outline-offset: -1px;
+	box-shadow: 0 0 0 2px #7effb2;
 }
 .progress-bar::after,
 .number {
@@ -39,7 +38,7 @@ body {
 	width: 110px;
 	height: 110px;
 	border-radius: inherit;
-	outline: inherit;
+	box-shadow: inherit;
 }
 .number {
 	font-size: 21px;


### PR DESCRIPTION
## Problem
Safari/iOS has trouble rendering a div with both outline and border-radius (it shows up as a square instead of a circle)

## Solution
 Changing outline to box-shadow fixes the issue on Safari while keeping the intended effect

Source: https://github.com/google/model-viewer/issues/662#issuecomment-1451606074